### PR TITLE
Fix wrong language text (#22)

### DIFF
--- a/en-US/middlewares/i18n.md
+++ b/en-US/middlewares/i18n.md
@@ -68,7 +68,7 @@ To use i18n feature in [pongo2](https://github.com/flosch/pongo2) with [middlewa
 m.Use(i18n.I18n(i18n.Options{
 	// Directory to load locale files. Default is "conf/locale".
 	Directory:	"conf/locale",
-	// Langauges that will be supported, order is meaningful.
+	// Languages that will be supported, order is meaningful.
 	Langs:		[]string{"en-US", "zh-CN"},
 	// Human friendly names corresponding to Langs list.
 	Names:		[]string{"English", "简体中文"},


### PR DESCRIPTION
The `language` text was wrong.